### PR TITLE
fix: add 'code-theme.styl' into 'style.styl' to enable the 'mac' code

### DIFF
--- a/source/css/style.styl
+++ b/source/css/style.styl
@@ -2,6 +2,7 @@
 @import "common/markdown.styl"
 @import "common/codeblock/highlight.styl"
 @import "common/codeblock/copy-code.styl"
+@import "common/codeblock/code-theme.styl"
 @import "layout/page.styl"
 @import "layout/_partial/local-search.styl"
 @import "layout/_partial/toc.styl"


### PR DESCRIPTION
add `code-theme.styl` to avoid the codeblock theme remains as default type when `mac` has been set as the `code_copy:style` in `_config.yml` when deployment