### PR TITLE
【更新】Twikoo 到最新 1.6.7 版本

### DIFF
--- a/layout/_partial/comment/twikoo.ejs
+++ b/layout/_partial/comment/twikoo.ejs
@@ -1,7 +1,7 @@
 <% if(theme.comment.use === 'twikoo' && theme.comment.twikoo.env_id) { %>
     <div class="twikoo-container">
         <script <%= theme.pjax.enable === true ? 'data-pjax' : '' %>
-                src="//cdn.jsdelivr.net/npm/twikoo@1.0.0/dist/twikoo.all.min.js"
+                src="https://cdn.staticfile.org/twikoo/1.6.7/twikoo.all.min.js"
         ></script>
         <div id="twikoo-comment"></div>
         <script <%= theme.pjax.enable === true ? 'data-pjax' : '' %>>

--- a/layout/_partial/comment/twikoo.ejs
+++ b/layout/_partial/comment/twikoo.ejs
@@ -1,7 +1,7 @@
 <% if(theme.comment.use === 'twikoo' && theme.comment.twikoo.env_id) { %>
     <div class="twikoo-container">
         <script <%= theme.pjax.enable === true ? 'data-pjax' : '' %>
-                src="https://cdn.staticfile.org/twikoo/1.6.7/twikoo.all.min.js"
+                src="//cdn.staticfile.org/twikoo/1.6.7/twikoo.all.min.js"
         ></script>
         <div id="twikoo-comment"></div>
         <script <%= theme.pjax.enable === true ? 'data-pjax' : '' %>>


### PR DESCRIPTION
## 更新详情

更新 Twikoo 到最新 1.6.7 版本，支持 Vercel 部署twikoo，可以在 `envID` 填入 vercel域名，将 `region` 留空不填

## 兼容测试

经过个人测试，使用完美，支持 `vercel自带域名` 和 `自己在vercel上绑定的个人域名`

## 私货

欢迎大家 Follow 一下我捏，谢谢
大家想要什么功能可以直接提 issue，我量力而行
欢迎去我的博客逛逛 [Anonymous Land](https://www.evanluo.top/)

**注：**请忽略我第一次的commit，第一次不小心加上了https

⚠️⚠️我手贱提交到 `master` 分支了，请作者别忘记改成 `dev`⚠️⚠️
