### PR TITLE
fix: fix code mistakes for getting theme parameters

### DIFF
--- a/layout/_partial/scripts.ejs
+++ b/layout/_partial/scripts.ejs
@@ -21,7 +21,7 @@ const {
     <%- __js('js/local-search.js') %>
 <% } %>
 
-<% if (t_code_block_tools.enable === true || t_code_copy.enable === true) { %>
+<% if (t_code_block_tools?.enable === true || t_code_copy?.enable === true) { %>
     <%- __js('js/code-block-tools.js') %>
 <% } %>
 


### PR DESCRIPTION
Fixed an error at startup：

Cannot read properties of undefined (reading 'enable')
at eval ("C:\\Users\\User\\Desktop\\hexo\\blog\\themes\\keep\\layout\\_partial\\scripts.ejs":45:62)
    at scripts (C:\Users\User\Desktop\hexo\blog\node_modules\ejs\lib\ejs.js:703:17)
    at _View._compiledSync (C:\Users\User\Desktop\hexo\blog\node_modules\hexo\lib\theme\view.js:132:24)
    at _View.renderSync (C:\Users\User\Desktop\hexo\blog\node_modules\hexo\lib\theme\view.js:59:25)
    at Object.partial (C:\Users\User\Desktop\hexo\blog\node_modules\hexo\lib\plugins\helper\partial.js:34:15)
    at eval ("C:\\Users\\User\\Desktop\\hexo\\blog\\themes\\keep\\layout\\layout.ejs":21:17)
    at layout (C:\Users\User\Desktop\hexo\blog\node_modules\ejs\lib\ejs.js:703:17)
    at _View._compiled (C:\Users\User\Desktop\hexo\blog\node_modules\hexo\lib\theme\view.js:136:50)
    at _View.render (C:\Users\User\Desktop\hexo\blog\node_modules\hexo\lib\theme\view.js:39:17)
    at C:\Users\User\Desktop\hexo\blog\node_modules\hexo\lib\theme\view.js:51:25
  