### PR TITLE
feat(footer): add the configuration of shields.io at the footer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -294,3 +294,12 @@ footer:
     enable: false       # Option values: true | false
     provider: github    # Option values: github | vercel | netlify | gitee | aliyun | tencent_cloud | upyun
     url:                # Your deployment provider url, Can be null
+  shields:
+    enable: false       # Option values: true | false
+    data:               
+      example1:
+        link_url: https://github.com/XPoet/hexo-theme-keep             # link_url for click, Can be null
+        img_url: https://img.shields.io/badge/hexo-keep%20v3.6.1-blue  # img_url  for show
+      example2:         # Add more
+        link_url:       # link_url for click, Can be null
+        img_url:        # img_url  for show

--- a/layout/_partial/footer.ejs
+++ b/layout/_partial/footer.ejs
@@ -2,7 +2,8 @@
 const {
   since: f_since,
   icp: f_icp,
-  site_deploy: f_site_deploy
+  site_deploy: f_site_deploy,
+  shields: f_shields
 } = theme.footer
 const { author: bi_author } = theme.base_info
 const { author: hexo_author } = config
@@ -56,6 +57,17 @@ const { site_uv: bsz_site_uv, site_pv: bsz_site_pv, enable: bsz_enable } = theme
                     ) %>
                 <% if (f_site_deploy?.url) { %>
                     </a>
+                <% } %>
+            </div>
+        <% } %>
+        <% if (f_shields?.enable === true) { %>
+            <div class="shields-info info-item">
+                <% for (var i in f_shields?.data){ %>
+                    <% if (f_shields?.data[i].img_url) { %>
+                        <a href="<%= f_shields?.data[i].link_url%>" target="_blank">
+                            <img src="<%= f_shields?.data[i].img_url%>" height="20px">
+                        </a>
+                    <% } %>
                 <% } %>
             </div>
         <% } %>


### PR DESCRIPTION
在页面footer添加了自定义 [Shields.io](https://shields.io/) 的设置，此处也可以设置为开往、虫洞等自定义的图标

![image](https://user-images.githubusercontent.com/87506951/212262972-f8fbed1b-ed1f-42bb-868d-4a23b06369c2.png)
