### PR TITLE
feat: only show posts matching website's language

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -347,3 +347,14 @@ inject:
     # - /js/custom-1.js
     # - /js/custom-2.js
     # - ...
+
+
+# ---------------------------------------------------------------------------------------
+# Only display posts that matches the website's language.
+#
+# The post should include 'lang:' attribute. An empty 'lang:' attribute will always diplay.
+# ---------------------------------------------------------------------------------------
+separate_by_language:
+  enable: false # Option values: true | false
+
+

--- a/layout/page.ejs
+++ b/layout/page.ejs
@@ -6,6 +6,9 @@
         <%- partial('_partial/first-screen') %>
     <% } %>
 
+    <!-- separate posts by language -->
+    <% separatePostsByLanguage() %>
+
     <!-- page content -->
     <div class="page-main-content border-box<%= is_home() ? ' is-home' : '' %>">
         <div class="page-main-content-top">

--- a/scripts/helpers/helper.js
+++ b/scripts/helpers/helper.js
@@ -42,6 +42,32 @@ hexo.extend.helper.register('getAuthorBadge', function (postCount, authorLabelCo
   }
 })
 
+hexo.extend.helper.register('separatePostsByLanguage', function () {
+  if (!this.theme.separate_by_language.enable) {
+    return
+  }
+
+  if (this.page.posts) {
+    this.page.posts = this.page.posts.filter(
+      (post) => post.lang === this.page.lang || post.lang === undefined
+    )
+  }
+
+  if (this.is_post()) {
+    let next = this.page.next
+    while (next && next.lang && next.lang !== this.page.lang) {
+      next = next.next
+    }
+    this.page.next = next
+
+    let prev = this.page.prev
+    while (prev && prev.lang && prev.lang !== this.page.lang) {
+      prev = prev.prev
+    }
+    this.page.prev = prev
+  }
+})
+
 const getSourceCdnUrl = (tyle, themeConfig, path) => {
   const version = require('../../package.json').version
   let { provider } = themeConfig?.cdn || {}


### PR DESCRIPTION
This feature might be useful if hosting a multi-language blog. 

For instance, if the blog is in English, it will only display posts with attribute `lang: en`, if the blog is in Chinese, it will display posts with attribute `lang: zh-CN`.