### PR TITLE
[issue: 284]fix: Unable to scroll horizontally when the code length is too long

### DIFF
--- a/source/js/code-block.js
+++ b/source/js/code-block.js
@@ -121,13 +121,16 @@ KEEP.initCodeBlock = () => {
       const codeBoxHeight = codeBox.getBoundingClientRect().height
       if (codeBoxHeight - limitHeight > 50) {
         codeBox.style.position = 'relative'
-        codeBox.style.overflowY = 'hidden'
+        codeBox.style.overflow = 'hidden'
         codeBox.style.height = `${limitHeight}px`
         const shrinkLineDom = document.createElement('div')
         shrinkLineDom.setAttribute('class', 'shrink-line flex-center')
         shrinkLineDom.style.height = `${tipNodeH}px`
         shrinkLineDom.style.top = `${limitHeight - tipNodeH}px`
         shrinkLineDom.addEventListener('click', () => {
+          codeBox.style.removeProperty('overflow')
+          codeBox.style.overflowY = 'hidden'
+          codeBox.style.overflowX = 'scroll'
           codeBox.style.height = `${codeBoxHeight}px`
           shrinkLineDom.style.display = 'none'
         })

--- a/source/js/code-block.js
+++ b/source/js/code-block.js
@@ -121,7 +121,7 @@ KEEP.initCodeBlock = () => {
       const codeBoxHeight = codeBox.getBoundingClientRect().height
       if (codeBoxHeight - limitHeight > 50) {
         codeBox.style.position = 'relative'
-        codeBox.style.overflow = 'hidden'
+        codeBox.style.overflowY = 'hidden'
         codeBox.style.height = `${limitHeight}px`
         const shrinkLineDom = document.createElement('div')
         shrinkLineDom.setAttribute('class', 'shrink-line flex-center')


### PR DESCRIPTION
When the height of the expanded code block exceeds the limit(250px), the code block will not be able to scroll horizontally.

solution:
When expanding the code block, remove overflow: hidden and change it to overflow-x: scroll