### PR TITLE
fix: fix the footer copyright period when it is within the same year

### DIFF
--- a/layout/_partial/footer.ejs
+++ b/layout/_partial/footer.ejs
@@ -25,7 +25,11 @@ const has_count_info = show_pv || show_uv || show_word_count
 %>
 <footer class="footer border-box">
     <div class="copyright-info info-item">
-        &copy;&nbsp;<% if (f_since) { %><span><%= f_since %></span>&nbsp;-&nbsp;<% } %><%= date(new Date(), 'YYYY') %>
+        &copy;&nbsp;<% if (f_since) { %>
+                        <span><%= f_since %></span>
+                    <% } if(f_since != date(new Date(), 'YYYY')) {%>
+                        &nbsp;-&nbsp;<%= date(new Date(), 'YYYY') %>
+                    <% } %>
         <% if (web_master) { %>
             &nbsp;<i class="fas fa-heart icon-animate"></i>&nbsp;&nbsp;<a href="<%- url_for('/') %>"><%= web_master %></a>
         <% } %>


### PR DESCRIPTION
before:

![image](https://github.com/user-attachments/assets/5c9a147e-ea43-4340-9c6f-c482925b50f0)

after:

![image](https://github.com/user-attachments/assets/bc4a4aad-568e-491f-a0b3-015d2d99a01b)
