### PR TITLE
fix: hide post-updated when it same as create time or update time is null

### DIFF
--- a/layout/_partial/post/post-meta-info.ejs
+++ b/layout/_partial/post/post-meta-info.ejs
@@ -34,11 +34,12 @@ const { created_datetime_icon, updated_datetime_icon } = theme?.post || {}
                 <i class="icon <%= created_datetime_icon || 'fa-solid fa-calendar-plus' %>"></i>&nbsp;
                 <span class="datetime"><%= date(post.date, theme.post?.datetime_format || 'YYYY-MM-DD HH:mm:ss') %></span>
             </span>
-
+            <% if(date(post.date, 'YYYY-MM-DD HH:mm:ss') !== date(post.updated, 'YYYY-MM-DD HH:mm:ss') && post.updated != null) { %>
             <span class="meta-info-item post-update-date">
                 <i class="icon <%= updated_datetime_icon || 'fa-solid fa-file-pen' %>"></i>&nbsp;
                 <span class="datetime" data-updated="<%= post.updated %>"><%= date(post.updated, theme.post?.datetime_format || 'YYYY-MM-DD HH:mm:ss') %></span>
             </span>
+            <% } %>
         <% } %>
 
         <% if (post.categories.length && (theme?.home?.category === true || page_type === 'post')) { %>


### PR DESCRIPTION
当配置 `updated_option: 'empty'` 时，更新时间显示为NAN，当文章创建时间和更新时间一致时依然显示更新时间。

修复：当文章更新时间与创建时间相同，甚至更新时间为空时，不再显示更新时间。