### PR TITLE
深浅色切换优化 / 修复加载闪屏的bug

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -42,6 +42,19 @@
             <% } %>
         <% }) %>
     <% } %>
+    <script>
+        (function () {
+            let theme = localStorage.getItem('KEEP-THEME-STATUS');
+            let classname = "";
+            if (!theme || (JSON.parse(theme).isAutoTheme)){
+                classname = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? "dark-mode" : "light-mode";
+            }
+            else{
+                classname = JSON.parse(theme).isDark ? "dark-mode" : "light-mode";
+            }
+            document.documentElement.classList.add(classname);
+        })();
+    </script>
     <%- exportThemeConfig() %>
 </head>
 

--- a/source/css/common/keep-style.styl
+++ b/source/css/common/keep-style.styl
@@ -155,28 +155,16 @@ root-color(mode) {
 
 :root {
   root-color('light')
+  display: none
 }
-
-
-@media (prefers-color-scheme light) {
-  :root {
-    root-color('light')
-  }
-}
-
-
-@media (prefers-color-scheme dark) {
-  :root {
-    root-color('dark')
-  }
-}
-
 
 .light-mode {
   root-color('light')
+  display: unset
 }
 
 
 .dark-mode {
   root-color('dark')
+  display: unset
 }

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -11,6 +11,7 @@ window.addEventListener('DOMContentLoaded', () => {
     encryptKey: 'KEEP-ENCRYPT',
     styleStatus: {
       isDark: false,
+      isAutoTheme: true,
       fontSizeLevel: 0,
       isShowToc: true
     },

--- a/source/js/toggle-theme.js
+++ b/source/js/toggle-theme.js
@@ -10,6 +10,7 @@ KEEP.initModeToggle = () => {
       document.documentElement.classList.add('light-mode')
       this.iconDom && (this.iconDom.className = 'fas fa-moon')
       KEEP.themeInfo.styleStatus.isDark = false
+      KEEP.themeInfo.styleStatus.isAutoTheme = this.isAutoTheme()
       KEEP.setStyleStatus()
     },
 
@@ -18,11 +19,15 @@ KEEP.initModeToggle = () => {
       document.documentElement.classList.remove('light-mode')
       this.iconDom && (this.iconDom.className = 'fas fa-sun')
       KEEP.themeInfo.styleStatus.isDark = true
+      KEEP.themeInfo.styleStatus.isAutoTheme = this.isAutoTheme()
       KEEP.setStyleStatus()
     },
 
     isDarkPrefersColorScheme() {
-      return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)')
+      return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+    },
+    isAutoTheme() {
+      return KEEP.themeInfo.styleStatus.isDark === this.isDarkPrefersColorScheme()
     },
 
     initModeStatus() {
@@ -40,10 +45,10 @@ KEEP.initModeToggle = () => {
 
       const styleStatus = KEEP.getStyleStatus()
 
-      if (styleStatus) {
+      if (styleStatus && !styleStatus.isAutoTheme) {
         styleStatus.isDark ? this.enableDarkMode() : this.enableLightMode()
       } else {
-        this.isDarkPrefersColorScheme().matches ? this.enableDarkMode() : this.enableLightMode()
+        this.isDarkPrefersColorScheme() ? this.enableDarkMode() : this.enableLightMode()
       }
     },
 
@@ -58,10 +63,11 @@ KEEP.initModeToggle = () => {
     },
 
     initModeAutoTrigger() {
-      const isDarkMode = this.isDarkPrefersColorScheme()
-      isDarkMode.addEventListener('change', (e) => {
-        e.matches ? this.enableDarkMode() : this.enableLightMode()
-      })
+      if(window.matchMedia){ //guard
+        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+          e.matches ? this.enableDarkMode() : this.enableLightMode()
+        })
+      }
     }
   }
 


### PR DESCRIPTION
1. 深浅色切换逻辑优化
原逻辑只能在页面打开时感知到系统的主题变换并自动切换。若上午打开，晚上再打开，主题无法自动切换。
修改后的逻辑参考了fluid主题的实现方式。当网页的主题和系统主题一致时，采用自动切换。

2. 修复加载闪屏的bug
原逻辑在网页主题和系统主题不一致时，加载过程会伴随一次屏幕闪烁。本修改修复了这个问题。