### PR TITLE
fix(headers): fix header styling (#388)

### DIFF
--- a/source/css/common/markdown.styl
+++ b/source/css/common/markdown.styl
@@ -99,6 +99,11 @@ $h6-font-size = 1.2rem
   }
 
 
+  del {
+    color var(--text-color-3)
+  }
+
+
   ul
   ol {
     li {
@@ -163,7 +168,8 @@ $h6-font-size = 1.2rem
   h6 {
     position relative
     display flex
-    justify-content space-between
+    gap 0.5rem  /* should be same with text word space */
+    justify-content left
     order 0
     box-sizing border-box
     padding-top 0.4rem
@@ -172,6 +178,17 @@ $h6-font-size = 1.2rem
     color var(--text-color-2)
     line-height 1.6
     border-bottom 1px solid var(--post-h-bottom-border-color)
+
+
+    em, del, code, strong {
+      margin 0
+    }
+
+
+    code {
+      padding-top 0.1rem
+      padding-bottom 0.4rem
+    }
 
 
     +keep-tablet() {
@@ -224,6 +241,10 @@ $h6-font-size = 1.2rem
     font-weight 600
     font-size $h1-font-size
 
+    code {
+      font-size $h1-font-size * 0.9
+    }
+
     +keep-tablet() {
       font-size $h1-font-size * 0.9
     }
@@ -243,6 +264,10 @@ $h6-font-size = 1.2rem
     font-weight 600
     font-size $h2-font-size
 
+    code {
+      font-size $h2-font-size * 0.9
+    }
+
     +keep-tablet() {
       font-size $h2-font-size * 0.9
     }
@@ -261,6 +286,10 @@ $h6-font-size = 1.2rem
   h3 {
     font-weight 550
     font-size $h3-font-size
+
+    code {
+      font-size $h3-font-size * 0.9
+    }
 
     +keep-tablet() {
       font-size $h3-font-size * 0.9
@@ -283,6 +312,10 @@ $h6-font-size = 1.2rem
     font-weight 550
     font-size $h4-font-size
 
+    code {
+      font-size $h4-font-size * 0.9
+    }
+
     +keep-tablet() {
       font-size $h4-font-size * 0.9
     }
@@ -304,6 +337,10 @@ $h6-font-size = 1.2rem
     font-weight 500
     font-size $h5-font-size
 
+    code {
+      font-size $h5-font-size * 0.9
+    }
+
     +keep-tablet() {
       font-size $h5-font-size * 0.9
     }
@@ -324,6 +361,10 @@ $h6-font-size = 1.2rem
   h6 {
     font-weight 500
     font-size $h6-font-size
+
+    code {
+      font-size $h6-font-size * 0.9
+    }
 
     +keep-tablet() {
       font-size $h6-font-size * 0.9
@@ -433,4 +474,3 @@ $h6-font-size = 1.2rem
     border-radius 0.3rem
   }
 }
-


### PR DESCRIPTION
bug修复: header 中的 code 元素顯示異常 #388 | fix bug: issue#388

1. 修复了原issue遇到的header中code显示异常问题 | fix the code styling issue of the headers
2. 此异常等价于strong(加粗), em(斜体), del(删除), 已共同修复 | the problem applies to bold, italic, strike-through as well, fixed together
3. 已经过测试, 见我的[测试网址](https://https://blog.000666.com/2025/05/12/hexo-keep-test/) | tested, please refer to the web mentioned
4. 已通过husky代码格式化 | format in style using husky

修复前 | Before:
<img width="600" alt="Screenshot 2025-05-27 at 13 12 23" src="https://github.com/user-attachments/assets/cb07f5d1-7399-4e70-bff7-e5e6640cd0d5" />
修复后 | After:
<img width="600" alt="Screenshot 2025-05-27 at 14 50 49" src="https://github.com/user-attachments/assets/350e08a8-bf24-4ab0-a1d1-47286f2e3c39" />

非前端专业人士, 第一次PR, 请多多指教 | This is my first PR >_<