### PR TITLE
fix(cdn): support path format for custom cdn provider via custom.type

### DIFF
--- a/scripts/helpers/cdn.js
+++ b/scripts/helpers/cdn.js
@@ -2,12 +2,34 @@
 
 'use strict'
 
+// Build the resource url according to the given cdn style.
+// - cdnjs: `${baseUrl}/${version}/${minPath}` (no `@version`, no `/source/`, minified files only)
+// - jsdelivr / unpkg: `${baseUrl}@${version}/source/${path}`
+// - raw: `${baseUrl}/${path}` (append the path directly to the base url, no version handling)
+const buildResourceUrl = (style, baseUrl, version, type, path) => {
+  switch (style) {
+    case 'cdnjs':
+      if (type === 'js') {
+        path = path.includes('.min.js') ? path : path.replace('.js', '.min.js')
+      } else {
+        path = path.includes('.min.css') ? path : path.replace('.css', '.min.css')
+      }
+      return `${baseUrl}/${version}/${path}`
+
+    case 'raw':
+      return `${baseUrl}/${path}`
+
+    case 'jsdelivr':
+    case 'unpkg':
+    default:
+      return `${baseUrl}@${version}/source/${path}`
+  }
+}
+
 const getSourceCdnUrl = (type, themeConfig, path) => {
   const version = require('../../package.json').version
   let { provider, custom } = themeConfig?.cdn || {}
   const isCustomCdn = custom?.enable || false
-  const customCdnUrl = custom?.url || ''
-  let cdnUrl = ''
 
   const providerEnum = {
     jsdelivr: 'jsdelivr',
@@ -24,40 +46,43 @@ const getSourceCdnUrl = (type, themeConfig, path) => {
     provider = providerEnum.custom
   }
 
+  let style = ''
+  let baseUrl = ''
+
   switch (provider?.toLocaleLowerCase()) {
     case providerEnum.jsdelivr:
-      cdnUrl = '//cdn.jsdelivr.net/npm/hexo-theme-keep'
-      if (type === 'js') {
-        return `<script src="${cdnUrl}@${version}/source/${path}"></script>`
-      } else {
-        return `<link rel="stylesheet" href="${cdnUrl}@${version}/source/${path}">`
-      }
+      style = 'jsdelivr'
+      baseUrl = '//cdn.jsdelivr.net/npm/hexo-theme-keep'
+      break
 
     case providerEnum.unpkg:
-      cdnUrl = '//unpkg.com/hexo-theme-keep'
-      if (type === 'js') {
-        return `<script src="${cdnUrl}@${version}/source/${path}"></script>`
-      } else {
-        return `<link rel="stylesheet" href="${cdnUrl}@${version}/source/${path}">`
-      }
+      style = 'unpkg'
+      baseUrl = '//unpkg.com/hexo-theme-keep'
+      break
 
     case providerEnum.cdnjs:
-      cdnUrl = 'https://cdnjs.cloudflare.com/ajax/libs/hexo-theme-keep'
-      if (type === 'js') {
-        path = path.includes('.min.js') ? path : path.replace('.js', '.min.js')
-        return `<script src="${cdnUrl}/${version}/${path}"></script>`
-      } else {
-        path = path.includes('.min.css') ? path : path.replace('.css', '.min.css')
-        return `<link rel="stylesheet" href="${cdnUrl}/${version}/${path}">`
-      }
+      style = 'cdnjs'
+      baseUrl = 'https://cdnjs.cloudflare.com/ajax/libs/hexo-theme-keep'
+      break
 
     case providerEnum.custom:
-      cdnUrl = customCdnUrl
-      if (type === 'js') {
-        return `<script src="${cdnUrl}@${version}/source/${path}"></script>`
-      } else {
-        return `<link rel="stylesheet" href="${cdnUrl}@${version}/source/${path}">`
-      }
+      // `custom.type` controls the url path format so that mirrors with different
+      // path structures (e.g. cdnjs / BootCDN) can be used correctly.
+      // Defaults to `jsdelivr` style to keep backward compatibility.
+      style = (custom?.type || 'jsdelivr').toLocaleLowerCase()
+      baseUrl = custom?.url || ''
+      break
+
+    default:
+      return
+  }
+
+  const resourceUrl = buildResourceUrl(style, baseUrl, version, type, path)
+
+  if (type === 'js') {
+    return `<script src="${resourceUrl}"></script>`
+  } else {
+    return `<link rel="stylesheet" href="${resourceUrl}">`
   }
 }
 


### PR DESCRIPTION
我这边根据这个 https://github.com/XPoet/hexo-theme-keep/issues/407#issuecomment-5031898476 问题简单写了个PR，把cdnjs的自定义给修复了，辛苦作者看下～